### PR TITLE
mkdir .git/hooks/ if it does not exist.

### DIFF
--- a/patatt/__init__.py
+++ b/patatt/__init__.py
@@ -1118,6 +1118,8 @@ def cmd_install_hook(cmdargs, config: dict):  # noqa
     if not gitrepo:
         logger.critical('Not in a git tree, cannot install hook')
         sys.exit(1)
+    if not os.path.exists(os.path.join(gitrepo, '.git', '.hooks')):
+        os.mkdir(hookdir)
     hookfile = os.path.join(gitrepo, '.git', 'hooks', 'sendemail-validate')
     if os.path.exists(hookfile):
         logger.critical('Hook already exists: %s', hookfile)


### PR DESCRIPTION
Fixes the following error observed running `patatt install-hook` in a
fresh kernel checkout:

Traceback (most recent call last):
  File "/usr/local/google/home/ndesaulniers/.local/bin/patatt", line 8, in <module>
    sys.exit(command())
  File "/usr/local/google/home/ndesaulniers/.local/lib/python3.9/site-packages/patatt/__init__.py", line 1204, in command
    _args.func(_args, config)
  File "/usr/local/google/home/ndesaulniers/.local/lib/python3.9/site-packages/patatt/__init__.py", line 1125, in cmd_install_hook
    with open(hookfile, 'w') as fh:
FileNotFoundError: [Errno 2] No such file or directory: '/android0/linux-next/.git/hooks/sendemail-validate'

Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>